### PR TITLE
Meimar/vcalc upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(Threads REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 
 # Add CXX flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-comment")
 
 # Include cmake utilities.
 include("${CMAKE_SOURCE_DIR}/cmake/symlink_to_bin.cmake")

--- a/include/BackEnd.h
+++ b/include/BackEnd.h
@@ -4,20 +4,53 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/BuiltinOps.h"
 
+// Pass manager
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
+#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+
+// Translation
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+#include "llvm/Support/raw_os_ostream.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/Verifier.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
+
 class BackEnd {
  public:
     BackEnd();
-
-    int emitMain();
-
+   
+    int emitModule();
+    int lowerDialects();
+    void dumpLLVM(std::ostream &os);
+ 
  protected:
     void setupPrintf();
     void printNewline();
-
+      
  private:
+    // MLIR
     mlir::MLIRContext context;
     mlir::ModuleOp module;
     std::shared_ptr<mlir::OpBuilder> builder;
-
     mlir::Location loc;
+
+    // LLVM 
+    llvm::LLVMContext llvm_context;
+    std::unique_ptr<llvm::Module> llvm_module;
 };

--- a/include/BackEnd.h
+++ b/include/BackEnd.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/BuiltinOps.h"
-
 // Pass manager
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -20,11 +16,17 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "llvm/Support/raw_os_ostream.h"
 
+// MLIR IR
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
 #include "mlir/IR/Verifier.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/BuiltinOps.h"
 
+// Dialects 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -34,14 +36,14 @@
 class BackEnd {
  public:
     BackEnd();
-   
+
     int emitModule();
     int lowerDialects();
     void dumpLLVM(std::ostream &os);
  
  protected:
     void setupPrintf();
-    void printNewline();
+    void createGlobalString(const char *str, const char *string_name);
       
  private:
     // MLIR

--- a/src/BackEnd.cpp
+++ b/src/BackEnd.cpp
@@ -1,26 +1,25 @@
 #include <assert.h>
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/TypeRange.h"
-#include "mlir/IR/Value.h"
-#include "mlir/IR/Verifier.h"
-
 #include "BackEnd.h"
 
 BackEnd::BackEnd() : loc(mlir::UnknownLoc::get(&context)) {
+
+    // Load Dialects.
     context.loadDialect<mlir::LLVM::LLVMDialect>();
-
+    context.loadDialect<mlir::arith::ArithDialect>();
+    context.loadDialect<mlir::scf::SCFDialect>();
+    context.loadDialect<mlir::cf::ControlFlowDialect>();
+    context.loadDialect<mlir::memref::MemRefDialect>(); 
+    
     builder = std::make_shared<mlir::OpBuilder>(&context);
-
-    // Open a new context and module.
     module = mlir::ModuleOp::create(builder->getUnknownLoc());
     builder->setInsertionPointToStart(module.getBody());
 
     setupPrintf();
 }
 
-int BackEnd::emitMain() {
+int BackEnd::emitModule() {
+    
     mlir::Type intType = mlir::IntegerType::get(&context, 32);
     auto mainType = mlir::LLVM::LLVMFunctionType::get(intType, {}, false);
     mlir::LLVM::LLVMFuncOp mainFunc = builder->create<mlir::LLVM::LLVMFuncOp>(loc, "main", mainType);
@@ -39,6 +38,47 @@ int BackEnd::emitMain() {
         return -1;
     }
     return 0;
+}
+
+int BackEnd::lowerDialects() {
+
+    // Set up the MLIR pass manager to iteratively lower all the Ops
+    mlir::PassManager pm(&context);
+
+    // Lower SCF to CF (ControlFlow)
+    pm.addPass(mlir::createConvertSCFToCFPass());
+
+    // Lower Arith to LLVM
+    pm.addPass(mlir::createArithToLLVMConversionPass());
+
+    // Lower MemRef to LLVM
+    pm.addPass(mlir::createFinalizeMemRefToLLVMConversionPass());
+
+    // Lower CF to LLVM
+    pm.addPass(mlir::createConvertControlFlowToLLVMPass());
+
+    // Finalize the conversion to LLVM dialect
+    pm.addPass(mlir::createReconcileUnrealizedCastsPass());
+
+    // Run the passes
+    if (mlir::failed(pm.run(module))) {
+        llvm::errs() << "Pass pipeline failed\n";
+        return 1;
+    }
+
+    return 0;
+}
+
+void BackEnd::dumpLLVM(std::ostream &os) {  
+    // The only remaining dialects in our module after the passes are builtin
+    // and LLVM. Setup translation patterns to get them to LLVM IR.
+    mlir::registerBuiltinDialectTranslation(context);
+    mlir::registerLLVMDialectTranslation(context);
+    llvm_module = mlir::translateModuleToLLVMIR(module, llvm_context);
+
+    // Create llvm ostream and dump into the output file
+    llvm::raw_os_ostream output(os);
+    output << *llvm_module;
 }
 
 void BackEnd::setupPrintf() {
@@ -81,45 +121,3 @@ void BackEnd::printNewline() {
     mlir::LLVM::LLVMFuncOp printfFunc = module.lookupSymbol<mlir::LLVM::LLVMFuncOp>("printf");
     builder->create<mlir::LLVM::CallOp>(loc, printfFunc, newLine);
 }
-
-// void BackEnd::setupPrintf() {
-//     // Create the global string "\n"
-//     mlir::Type charType = mlir::IntegerType::get(&context, 8);
-//     auto gvalue = mlir::StringRef("\n\0", 2);
-//     auto type = mlir::LLVM::LLVMArrayType::get(charType, gvalue.size());
-//     builder->create<mlir::LLVM::GlobalOp>(loc, type, /*isConstant=*/true,
-//                                mlir::LLVM::Linkage::Internal, "newline",
-//                                builder->getStringAttr(gvalue), /*alignment=*/0);
-
-//     // Create a function declaration for printf, the signature is:
-//     //   * `i32 (i8*, ...)`
-//     mlir::Type intType = mlir::IntegerType::get(&context, 32);
-//     auto llvmI8PtrTy = mlir::LLVM::LLVMPointerType::get(charType);
-//     auto llvmFnType = mlir::LLVM::LLVMFunctionType::get(intType, llvmI8PtrTy,
-//                                                         /*isVarArg=*/true);
-
-//     // Insert the printf function into the body of the parent module.
-//     builder->create<mlir::LLVM::LLVMFuncOp>(loc, "printf", llvmFnType);
-// }
-
-// void BackEnd::printNewline() {
-//     /* Note: a lot of this comes from the MLIR "toy" tutorial */
-//     mlir::LLVM::GlobalOp global;
-//     if (!(global = module.lookupSymbol<mlir::LLVM::GlobalOp>("newline"))) {
-//         llvm::errs() << "missing format string!\n";
-//         return;
-//     }
-
-//     // Get the pointer to the first character in the global string.
-//     mlir::Value globalPtr = builder->create<mlir::LLVM::AddressOfOp>(loc, global);
-//     mlir::Value cst0 = builder->create<mlir::LLVM::ConstantOp>(loc, builder->getI64Type(),
-//                                                         builder->getIndexAttr(0));
-
-//     mlir::Type charType = mlir::IntegerType::get(&context, 8);
-//     mlir::Value newLine = builder->create<mlir::LLVM::GEPOp>(loc,
-//                           mlir::LLVM::LLVMPointerType::get(charType),
-//                           globalPtr, mlir::ArrayRef<mlir::Value>({cst0, cst0}));
-
-//     mlir::LLVM::LLVMFuncOp printfFunc = module.lookupSymbol<mlir::LLVM::LLVMFuncOp>("printf");
-//     builder->create<mlir::LLVM::CallOp>(loc, printfFunc, newLine);
-// }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,12 +28,6 @@ int main(int argc, char **argv) {
   // Get the root of the parse tree. Use your base rule name.
   antlr4::tree::ParseTree *tree = parser.file();
 
-  // HOW TO USE A LISTENER
-  // Make the listener
-  // MyListener listener;
-  // Walk the tree
-  // antlr4::tree::ParseTreeWalker::DEFAULT.walk(&listener, tree);
-
   // HOW TO USE A VISITOR
   // Make the visitor
   // MyVisitor visitor;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,12 +40,11 @@ int main(int argc, char **argv) {
   // Visit the tree
   // visitor.visit(tree);
 
+  std::ofstream os(argv[2]);
   BackEnd backend;
-  backend.emitMain();
-
-  // HOW TO WRITE OUT.
-  // std::ofstream out(argv[2]);
-  // out << "This is out...\n";
+  backend.emitModule();
+  backend.lowerDialects();
+  backend.dumpLLVM(os);
 
   return 0;
 }

--- a/tests/VCalcConfig.json
+++ b/tests/VCalcConfig.json
@@ -1,6 +1,5 @@
 {
-  "inDir": "<inDir>",
-  "outDir": "<outDir>",
+  "testDir": "<testDir>",
   "testedExecutablePaths": {
     "<team id>": "<path_to_vcalc_exe>"
   },
@@ -20,7 +19,7 @@
       },
       {
         "stepName": "lli",
-        "executablePath": "/cshome/cmput415/415-resources/llvm-project/build/bin/lli",
+        "executablePath": "<path_to_lli>",
         "arguments": [
          "$INPUT"
         ],

--- a/tests/input/.gitkeep
+++ b/tests/input/.gitkeep
@@ -1,2 +1,0 @@
-This file is useless. Just meant to keep the directory around. Delete it if
-you want, but it won't affect your tests.

--- a/tests/output/.gitkeep
+++ b/tests/output/.gitkeep
@@ -1,2 +1,0 @@
-This file is useless. Just meant to keep the directory around. Delete it if
-you want, but it won't affect your tests.

--- a/tests/pre-commit
+++ b/tests/pre-commit
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Place this script in .git/hooks/ to ensure that your test structure
+# is correct on every commit. You can also run it ad hoc.
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# Get the full path to the git repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Extract the name of the project directory from the repository root path
+PROJECT_DIR_NAME=$(basename "$REPO_ROOT")
+
+# The team name is the substring of the project directory from the right of the
+# first '-'. For example vcalc-unicorn -> unicorn
+TEAM_NAME=${PROJECT_DIR_NAME#*-}
+TEST_DIR="${REPO_ROOT}/tests"
+TESTFILES_DIR="${TEST_DIR}/testfiles"
+EXPECTED_PACKAGE="${TESTFILES_DIR}/${TEAM_NAME}"
+
+# Assert that the test directory is present.
+if [ ! -d $TEST_DIR ]; then
+    echo -e "${RED} Could not find expected directory: ${TEST_DIR} ${NC}"
+    exit 1
+fi
+
+# Assert that a testfiles directory is present.
+if [ ! -d $TESTFILES_DIR ]; then
+    echo -e "${RED}Could not find expected directory: ${TESTFILES_DIR}${NC}"
+    exit 1
+fi
+
+# Assert that the expected first package is present.
+if [ ! -d $EXPECTED_PACKAGE ]; then
+    echo -e "--- ${RED}ERROR:${NC} Missing a self-named package in testfiles!"
+    echo -e "--- Expected a package named ${YELLOW}~/tests/testfiles/${PROJECT_DIR_NAME}${NC}" 
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
 A summary of the changes:
 
* `lowerDialects()` method in `BackEnd`: Implement lowering dialects with the pass manager. The bennefit here is that not all registered dialects need be present in the final mlir module in order to be lowered. This means teams chosing only to work with the LLVM dialect can still use this infrastructure without a problem.

* `createGlobalString()` method in `BackEnd`: I thought a little more push in the direction of "Do things with `mlir::Value` instead of calling the runtime" could be achieved by providing a clear path towards printing integers and characters.
 
 * Add the commit hook script from GeneratorBase earlier today.
 
Also, I figured we can use this PR as a convenient location to prompt a discussion about the strategy for moving higher up the MLIR tree as we are starting to do with the introduction of the 3 dialects: `arith`, `memref` and `scf`. Some of the challenges I have encountered with writting VCalc include:

* The `memref` alloca/alloc types have equivalent C-types that are structs with 5+ fields to track the metadata (dimension, stride etc) around the `memref`. This makes passing a simple pointer to the underlying buffer into the runtime challenging. I avoided this in VCalc since printing formats for integers and vectors are relatively simple, however this could become more of a concern in Gazprea when printing matrices.

* Mixing `scf` and manual basic block control flow doesn't work. I ran into this when I tried to implement if statements using `scf` and while loops using manual basic blocks. All `scf` ops only allow one basic block in its body, so nesting a manual while loop in an `scf` If becomes impossible. This imposes that control flow be implemented "all or nothing" with `scf`. In my short experience in VCalc I think this is ok. The `scf` dialect is highly expressive. It even has support for `do-while` out of the box so all CF from VCalc to Gazprea should be doable.

* `arith` is brought in somewhat incidentally because the types for indices into `memref` buffers are found in this dialect. Generally `arith` just provides just what is claims to be, thin wrappers over the LLVM dialect arithmetic. Although it does add some new Ops like Max and Min which LLVM dialect doesn't have. 

Overall I think the benefits outweigh the challenges for these three dialects. I think my plan should be to implement some basic matrix / tuples / functions using these dialects to see if the ease of implementation continues into Gazprea features? 

Thanks and let me know what you guys think

\- Justin
 